### PR TITLE
Add RabbitMQ service to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,14 @@ services:
     volumes:
       - mongo_data:/data/db
 
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    restart: unless-stopped
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+
   orchard_api:
     build:
       context: ./teste
@@ -19,21 +27,26 @@ services:
     environment:
       MONGODB_URI: "mongodb://mongo:27017/orchard_db"
       PORT: 4000
+      RABBITMQ_URI: "amqp://rabbitmq:5672"
     ports:
       - "4000:4000"
     depends_on:
       - mongo
+      - rabbitmq
 
   api1:
     build:
       context: ./advanced-topics
       dockerfile: Dockerfile
     container_name: api1-app
+    environment:
+      RABBITMQ_URI: "amqp://rabbitmq:5672"
     ports:
       - "8080:8080"
     restart: unless-stopped
     depends_on:
       - mongo
+      - rabbitmq
 
   frontend:
     build:

--- a/frontend/src/pages/HarvestForm.jsx
+++ b/frontend/src/pages/HarvestForm.jsx
@@ -93,7 +93,12 @@ export default function HarvestForm() {
   }, [id]);
 
   const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    let value = e.target.value;
+    if (e.target.name === "orchardId") {
+      const parsed = parseInt(value, 10);
+      value = Number.isNaN(parsed) ? value : parsed;
+    }
+    setForm({ ...form, [e.target.name]: value });
   };
 
   const handleSubmit = async (e) => {

--- a/frontend/src/pages/Reports.jsx
+++ b/frontend/src/pages/Reports.jsx
@@ -96,7 +96,12 @@ export default function Reports() {
   }, [navigate]);
 
   const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    let value = e.target.value;
+    if (e.target.name === "orchardId") {
+      const parsed = parseInt(value, 10);
+      value = Number.isNaN(parsed) ? value : parsed;
+    }
+    setForm({ ...form, [e.target.name]: value });
   };
 
   const handleSubmit = async (e) => {


### PR DESCRIPTION
## Summary
- include RabbitMQ container
- expose ports 5672 and 15672
- set `RABBITMQ_URI` environment variable for `orchard_api` and `api1`
- make `orchard_api` and `api1` depend on RabbitMQ
- convert orchardId values to integers in harvest and report forms

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ecdd9a2088328b48a3af87030469d