### PR TITLE
Fix report creation without orchardId

### DIFF
--- a/teste/src/graphql/resolvers.js
+++ b/teste/src/graphql/resolvers.js
@@ -157,8 +157,12 @@ module.exports = {
 
     // Reports
     createReport: async (_parent, { input }) => {
+      const orchardId =
+        input.orchardId !== undefined && input.orchardId !== ''
+          ? parseInt(input.orchardId, 10)
+          : undefined;
       const rpt = new Report({
-        orchardId: input.orchardId,
+        orchardId,
         generatedAt: input.generatedAt || Date.now(),
         content: input.content,
       });
@@ -184,16 +188,21 @@ module.exports = {
 
       return saved;
     },
-    updateReport: async (_parent, { id, input }) =>
-      await Report.findByIdAndUpdate(
+    updateReport: async (_parent, { id, input }) => {
+      const orchardId =
+        input.orchardId !== undefined && input.orchardId !== ''
+          ? parseInt(input.orchardId, 10)
+          : undefined;
+      return await Report.findByIdAndUpdate(
         id,
         {
-          orchardId: input.orchardId,
+          orchardId,
           generatedAt: input.generatedAt || Date.now(),
           content: input.content,
         },
         { new: true }
-      ),
+      );
+    },
     deleteReport: async (_parent, { id }) => {
       await Report.findByIdAndDelete(id);
       return true;

--- a/teste/src/graphql/typeDefs.js
+++ b/teste/src/graphql/typeDefs.js
@@ -37,7 +37,7 @@ module.exports = gql`
 
   type Report {
     id: ID!
-    orchardId: Int!
+    orchardId: Int
     generatedAt: Date!
     content: String!
     createdAt: Date
@@ -68,7 +68,7 @@ module.exports = gql`
   }
 
   input ReportInput {
-    orchardId: Int!
+    orchardId: ID
     generatedAt: Date
     content: String!
   }

--- a/teste/src/models/Report.js
+++ b/teste/src/models/Report.js
@@ -2,7 +2,8 @@ const { Schema, model } = require('mongoose');
 
 const reportSchema = new Schema(
   {
-    orchardId: { type: Number, required: true },
+    // orchardId pode ser opcional em alguns relatórios
+    orchardId: { type: Number },
     generatedAt: { type: Date, default: Date.now },
     content: { type: String, required: true },
   },


### PR DESCRIPTION
## Summary
- relax Report.orchardId requirement in the model
- allow null orchardId in GraphQL schema
- parse orchardId value in create/update resolvers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861e7cf2fe083289802c9e61b719f4f